### PR TITLE
Adding nrf52840 usage example to groundhog-nrf52

### DIFF
--- a/crates/groundhog-nrf52/src/lib.rs
+++ b/crates/groundhog-nrf52/src/lib.rs
@@ -1,3 +1,42 @@
+//! Contains a nrf52-compatible implementation of the `RollingTimer` trait.
+//! 
+//! The `GlobalRollingTimer` is especially helpful if you are running RTIC on
+//! a nrf52 board. The built-in cycle counter (`CYCCNT`) which is commonly used
+//! as a monotonic counter will not work when the debugger is not attached, which
+//! in turn will make scheduling operations not work as expected.
+//! 
+//! # Usage
+//!
+//! To use the the `GlobalRollingTimer` with RTIC, it first needs to be selected
+//! as the monotonic timer (here on top of the nrf52840 hal):
+//! 
+//! ```
+//! #[rtic::app(device = nrf52840_hal::pac, peripherals = true, monotonic = groundhog_nrf52::GlobalRollingTimer)]
+//! ```
+//! 
+//! During the init phase it needs to be initialized with a concrete timer implementation:
+//! 
+//! ```
+//! #[init]
+//! fn init(ctx: init::Context) -> init::LateResources {
+//!     // using TIMER0 here
+//!     GlobalRollingTimer::init(ctx.device.TIMER0);
+//!     // ...
+//! }
+//! ```
+//! 
+//! Then, you can specify the schedule interval in microseconds as part of your task:
+//! 
+//! ```
+//! #[task]
+//! fn my_task(ctx: my_task::Context) {
+//!     ctx.schedule
+//!         .my_task(ctx.scheduled + 1_000_000)
+//!         .unwrap();
+//! }
+//! ```
+//! In this case the task will be scheduled again one second later.
+//! 
 #![no_std]
 
 use groundhog::RollingTimer;


### PR DESCRIPTION
This PR adds a basic usage rustdoc block that shows how to combine
the timer together with RTIC.